### PR TITLE
Update wait_until_finished to properly detect final workflow status.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,6 @@ Running a workflow and downloading the results::
     >>> import alpine as AlpineAPI
     >>> session = AlpineAPI.APIClient(host, port, username, password)
     >>> process_id = session.workfile.process.run(workfile_id)
-    >>> session.workfile.process.wait_until_finished(process_id)
+    >>> session.workfile.process.wait_until_finished(workfile_id, process_id)
     >>> results = session.workfile.process.download(workfile_id, process_id)
 

--- a/alpine/workfile.py
+++ b/alpine/workfile.py
@@ -404,8 +404,8 @@ class Workfile(AlpineObject):
             """
             Downloads a workflow run result.
 
-            :param str workflow_id: ID of the workflow.
-            :param ste process_id: ID of a particular workflow run.
+            :param int workflow_id: ID of the workflow.
+            :param str process_id: ID of a particular workflow run.
             :return: JSON object of workflow results.
             :rtype: dict
             :exception WorkspaceNotFoundException: The workspace does not exist.
@@ -459,13 +459,14 @@ class Workfile(AlpineObject):
                 raise StopFlowFailureException("Stopping the workflow failed with status {0}: {1}"
                                                .format(response.status_code, response.reason))
 
-        def wait_until_finished(self, process_id, verbose=False, query_time=10, timeout=3600):
+        def wait_until_finished(self, workflow_id, process_id, verbose=False, query_time=10, timeout=3600):
             """
             Waits for a running workflow to finish.
 
-            :param str process_id: Process ID of the workflow.
+            :param int workflow_id: ID of a particular workflow run.
+            :param str process_id: ID of a particular workflow run.
             :param bool verbose: Optionally print approximate run time.
-            :param float query_time: Number of seconds between status queries.
+            :param float query_time: Number of seconds between status queries. Minimum of 1 second.
             :param float timeout: Amount of time in seconds to wait for workflow to finish. Will stop if exceeded.
             :return: Workflow run status.
             :rtype: str
@@ -474,17 +475,20 @@ class Workfile(AlpineObject):
 
             Example::
 
-                >>> session.workfile.process.wait_until_finished(process_id = process_id)
+                >>> session.workfile.process.wait_until_finished(workflow_id = workflow_id, process_id = process_id)
 
             """
+            query_time = max(1, query_time)
 
             start = time.time()
-            self.logger.debug("Waiting for process ID: <{0}> to complete...".format(process_id))
-            wait_count = 0
 
+            self.logger.debug("Waiting for process ID: {0} to complete...".format(process_id))
+
+            # workflow_status = self.query_status2(workflow_id, process_id)
             workflow_status = self.query_status(process_id)
+
             while workflow_status == "WORKING":  # loop while waiting for workflow to complete
-                wait_count += 1
+
                 wait_total = time.time() - start
 
                 if wait_total >= timeout:
@@ -494,11 +498,18 @@ class Workfile(AlpineObject):
                         " It now has status '{2}'.".format(process_id, timeout, stop_status))
 
                 if verbose:
-                    print("\rWorkflow in progress for ~{0:.2f} seconds.".format(wait_total)),
+                    print("\rWorkflow in progress for ~{0:.1f} seconds.".format(wait_total)),
 
                 time.sleep(query_time)
 
-                if workflow_status == "FAILED":
-                    raise RunFlowFailureException("The workflow with process ID: <{0}> failed.".format(process_id))
                 workflow_status = self.query_status(process_id)
-            return workflow_status
+
+            if verbose:
+                print("")
+
+            # If workflow is finished - find the final status, otherwise return status in progress.
+            time.sleep(1)
+            final_results = self.download_results(workflow_id, process_id)
+            status = self.get_metadata(final_results)['status']
+
+            return status

--- a/alpine/workfile.py
+++ b/alpine/workfile.py
@@ -482,7 +482,7 @@ class Workfile(AlpineObject):
 
             start = time.time()
 
-            self.logger.debug("Waiting for process ID: {0} to complete...".format(process_id))
+            self.logger.debug("Waiting for process ID: <{0}> to complete...".format(process_id))
 
             # workflow_status = self.query_status2(workflow_id, process_id)
             workflow_status = self.query_status(process_id)

--- a/doc/JupyterNotebookExamples/Introduction.ipynb
+++ b/doc/JupyterNotebookExamples/Introduction.ipynb
@@ -7,6 +7,7 @@
     "# Introduction\n",
     "\n",
     "Let's start with a example of an Alpine API session.\n",
+    "\n",
     "1. Initialize a session.\n",
     "1. Take a tour some commands.\n",
     "1. Run a workflow and download the results."

--- a/doc/JupyterNotebookExamples/Introduction.ipynb
+++ b/doc/JupyterNotebookExamples/Introduction.ipynb
@@ -55,13 +55,14 @@
     "You'll also need your Alpine username and password.\n",
     "\n",
     "I've stored my connection information in a configuration file named `alpine_login.conf` that looks something like this:\n",
-    "\n",
+    "```JSON\n",
     "    {\n",
     "        \"host\": \"AlpineHost\",\n",
     "        \"port\": \"PortNum\",\n",
     "        \"username\": \"fakename\",\n",
     "        \"password\": \"12345\"\n",
-    "    }"
+    "    }\n",
+    "```"
    ]
   },
   {
@@ -180,7 +181,7 @@
       " u'organization_uuid': None,\n",
       " u'users_license_limit_reached': False,\n",
       " u'vendor': u'alpine',\n",
-      " u'version': u'6.3.0.0.5302-3f9996dea\\n',\n",
+      " u'version': u'6.3.0.0.5313-80ba3a0fc\\n',\n",
       " u'workflow_enabled': True}\n"
      ]
     }
@@ -200,7 +201,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "u'6.3.0.0.5302-3f9996dea'\n"
+      "u'6.3.0.0.5313-80ba3a0fc'\n"
      ]
     }
    ],
@@ -337,7 +338,7 @@
       " u'roles': [u'admin'],\n",
       " u'subscribed_to_emails': False,\n",
       " u'tags': [],\n",
-      " u'title': u'Assistant Regional Manager',\n",
+      " u'title': u'Assistant to the Regional Manager',\n",
       " u'user_type': u'analytics_developer',\n",
       " u'username': u'tjbay',\n",
       " u'using_default_image': True}\n"
@@ -345,7 +346,7 @@
     }
    ],
    "source": [
-    "pprint(session.user.update(user_id, title = \"Assistant Regional Manager\"))"
+    "pprint(session.user.update(user_id, title = \"Assistant to the Regional Manager\"))"
    ]
   },
   {
@@ -389,25 +390,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Workflow in progress for ~45.72 seconds.        "
+      "Workflow in progress for ~40.3 seconds.        \n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "'FINISHED'"
+       "u'SUCCESS'"
       ]
      },
      "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
     }
    ],
    "source": [
@@ -416,7 +410,8 @@
     "\n",
     "process_id = session.workfile.process.run(workflow_id)\n",
     "\n",
-    "session.workfile.process.wait_until_finished(process_id = process_id,\n",
+    "session.workfile.process.wait_until_finished(workflow_id = workflow_id,\n",
+    "                                             process_id = process_id,\n",
     "                                             verbose = True,\n",
     "                                             query_time = 5)"
    ]
@@ -439,12 +434,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{u'flowMetaInfo': {u'endTime': u'2017-03-07T15:27:27.740-0800',\n",
+      "{u'flowMetaInfo': {u'endTime': u'2017-03-14T16:57:24.306-0700',\n",
       "                   u'executeUser': u'7',\n",
       "                   u'noOfError': 0,\n",
       "                   u'noOfNodesProcessed': 3,\n",
-      "                   u'processId': u'3f5e7d3c-462e-462b-81e1-1eef81c63b2e',\n",
-      "                   u'startTime': u'2017-03-07T15:26:40.830-0800',\n",
+      "                   u'processId': u'dad3bfc0-43b1-439f-ab16-f9f761621fbd',\n",
+      "                   u'startTime': u'2017-03-14T16:56:37.641-0700',\n",
       "                   u'status': u'SUCCESS',\n",
       "                   u'workflowId': u'1269',\n",
       "                   u'workflowName': u'Data ETL'},\n",


### PR DESCRIPTION
1) A few small doc/type corrections

2) Fixes for wait_until_finished - now properly detects a failed workflow
a. Signature changes - workflow_id is added
b. Sets a minimum of 1 second for query_time. 
c. After detecting workflow being finished, waits 1 second. This eliminates errors between the workflow finishing and the .fr file being saved. May need to up slightly.
d. After detecting workflow being finished, downloads the fr file and uses metadata to determine the final state of the workflow. This is more accurate than using query_status to detect failures.